### PR TITLE
Change generic Cordova widget ID

### DIFF
--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <widget
-  id="hello.world"
+  id="com.eclipsesource.hello.world"
   version="0.2.0"
   android-versionCode="$BUILD_NUMBER"
   ios-CFBundleVersion="$BUILD_NUMBER">


### PR DESCRIPTION
Changed hello.world to com.eclipsesource.hello.world since we need
a unique app entitlement for iOS push notifications.